### PR TITLE
Various Modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ I don't like the delay after pressing `y` for doing regular yanks. Therefore, I'
 	vmap <silent> DM  :<C-U>call ForAllMatches('delete', {'visual':1, 'inverse':1})<CR>
 	vmap <silent> YM  :<C-U>call ForAllMatches('yank',   {'visual':1})<CR>
 	vmap <silent> YI  :<C-U>call ForAllMatches('yank',   {'visual':1, 'inverse':1})<CR>
+
+### Configuration Options
+
+#### Override the Destination Default Destination Register
+
+Default Setting = `'"'`
+
+It is possible that a user may want to use a different register by default for
+this plugin to save information to.
+
+To configure the destination register to the `+` register for example:
+
+```vimscript
+let g:YankMatches#ClipboardRegister='+'
+```

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ I don't like the delay after pressing `y` for doing regular yanks. Therefore, I'
 
 #### Override the Destination Default Destination Register
 
-Default Setting = `'"'`
+By default, this plugin will save your matched text in the register defined by
+the `clipboard` setting, or if that isn't defined it will save in the `"`
+register.
 
-It is possible that a user may want to use a different register by default for
-this plugin to save information to.
+However, It is possible that a user may want to use a different register for
+this plugin.
 
-To configure the destination register to the `+` register for example:
+To configure the destination register to the `a` register for example:
 
 ```vimscript
-let g:YankMatches#ClipboardRegister='+'
+let g:YankMatches#ClipboardRegister='a'
 ```

--- a/plugin/yankmatches.vim
+++ b/plugin/yankmatches.vim
@@ -83,13 +83,19 @@ function! ForAllMatches (command, options)
     " Make yanked lines available for putting...
     " First however, check if the user has configured the option to change the
     " register that the information is yanked or deleted to. If no such
-    " configuration exists, then default to the '"' register.
-    if exists('g:YankMatches#ClipboardRegister')
-        let l:command = ':let @' . g:YankMatches#ClipboardRegister . ' = yanked'
-        execute 'normal! ' . l:command . "\<cr>"
-    else
-        let @" = l:yanked
+    " configuration exists, then check the clipboard setting.
+    if !exists('g:YankMatches#ClipboardRegister')
+        let l:clipboard_flags = split(&clipboard, ',')
+        if index(l:clipboard_flags, 'unnamedplus') >= 0
+            let g:YankMatches#ClipboardRegister='+'
+        elseif index(l:clipboard_flags, 'unnamed') >= 0
+            let g:YankMatches#ClipboardRegister='*'
+        else
+            let g:YankMatches#ClipboardRegister='"'
+        endif
     endif
+    let l:command = ':let @' . g:YankMatches#ClipboardRegister . ' = yanked'
+    execute 'normal! ' . l:command . "\<cr>"
 
     " Return to original position...
     call setpos('.', l:orig_pos)

--- a/plugin/yankmatches.vim
+++ b/plugin/yankmatches.vim
@@ -24,16 +24,17 @@ set cpo&vim
 
 "====[ Interface ]====================================================
 "
-" Change these if you want different commands for the specified actions...
+" Example mappings
 "
-nmap <silent> dm  :     call ForAllMatches('delete', {})<CR>
-nmap <silent> DM  :     call ForAllMatches('delete', {'inverse':1})<CR>
-nmap <silent> YM  :     call ForAllMatches('yank',   {})<CR>
-nmap <silent> YI  :     call ForAllMatches('yank',   {'inverse':1})<CR>
-vmap <silent> dm  :<C-U>call ForAllMatches('delete', {'visual':1})<CR>
-vmap <silent> DM  :<C-U>call ForAllMatches('delete', {'visual':1, 'inverse':1})<CR>
-vmap <silent> YM  :<C-U>call ForAllMatches('yank',   {'visual':1})<CR>
-vmap <silent> YI  :<C-U>call ForAllMatches('yank',   {'visual':1, 'inverse':1})<CR>
+" I will set what I want explicitly in my vimrc
+" nmap <silent> dm  :     call ForAllMatches('delete', {})<CR>
+" nmap <silent> DM  :     call ForAllMatches('delete', {'inverse':1})<CR>
+" nmap <silent> YM  :     call ForAllMatches('yank',   {})<CR>
+" nmap <silent> YI  :     call ForAllMatches('yank',   {'inverse':1})<CR>
+" vmap <silent> dm  :<C-U>call ForAllMatches('delete', {'visual':1})<CR>
+" vmap <silent> DM  :<C-U>call ForAllMatches('delete', {'visual':1, 'inverse':1})<CR>
+" vmap <silent> YM  :<C-U>call ForAllMatches('yank',   {'visual':1})<CR>
+" vmap <silent> YI  :<C-U>call ForAllMatches('yank',   {'visual':1, 'inverse':1})<CR>
 
 function! ForAllMatches (command, options)
     " Remember where we parked...

--- a/plugin/yankmatches.vim
+++ b/plugin/yankmatches.vim
@@ -81,7 +81,15 @@ function! ForAllMatches (command, options)
     endfor
 
     " Make yanked lines available for putting...
-    let @" = yanked
+    " First however, check if the user has configured the option to change the
+    " register that the information is yanked or deleted to. If no such
+    " configuration exists, then default to the '"' register.
+    if exists('g:YankMatches#ClipboardRegister')
+        let l:command = ':let @' . g:YankMatches#ClipboardRegister . ' = yanked'
+        execute 'normal! ' . l:command . "\<cr>"
+    else
+        let @" = yanked
+    endif
 
     " Return to original position...
     call setpos('.', orig_pos)

--- a/plugin/yankmatches.vim
+++ b/plugin/yankmatches.vim
@@ -63,7 +63,7 @@ function! ForAllMatches (command, options)
     if inverted
         let inverted_line_nums = range(start_line, end_line)
         for line_num in matched_line_nums
-            call remove(inverted_line_nums, line_num-1)
+            call remove(inverted_line_nums, line_num-start_line)
         endfor
         let matched_line_nums = reverse(inverted_line_nums)
     endif

--- a/plugin/yankmatches.vim
+++ b/plugin/yankmatches.vim
@@ -2,14 +2,14 @@
 " Maintainer:	Damian Conway
 " License:	This file is placed in the public domain.
 
-if exists("loaded_delete_matches")
+if exists('loaded_delete_matches')
     finish
 endif
-let loaded_delete_matches = 1
+let g:loaded_delete_matches = 1
 
 " Preserve external compatibility options, then enable full vim compatibility...
-let s:save_cpo = &cpo
-set cpo&vim
+let s:save_cpo = &cpoptions
+set cpoptions&vim
 
 
 " Originally just:
@@ -38,45 +38,45 @@ set cpo&vim
 
 function! ForAllMatches (command, options)
     " Remember where we parked...
-    let orig_pos = getpos('.')
+    let l:orig_pos = getpos('.')
 
     " Work out the implied range of lines to consider...
-    let in_visual = get(a:options, 'visual', 0)
-    let start_line = in_visual ? getpos("'<'")[1] : 1
-    let end_line   = in_visual ? getpos("'>'")[1] : line('$')
+    let l:in_visual = get(a:options, 'visual', 0)
+    let l:start_line = l:in_visual ? getpos("'<'")[1] : 1
+    let l:end_line   = l:in_visual ? getpos("'>'")[1] : line('$')
 
     " Are we inverting the selection???
-    let inverted = get(a:options, 'inverse', 0)
+    let l:inverted = get(a:options, 'inverse', 0)
 
     " Are we modifying the buffer???
-    let deleting = a:command == 'delete'
+    let l:deleting = a:command ==? 'delete'
 
     " Honour smartcase (which :lvimgrep doesn't, by default)
-    let sensitive = &ignorecase && &smartcase && @/ =~ '\u' ? '\C' : ''
+    let l:sensitive = &ignorecase && &smartcase && @/ =~# '\u' ? '\C' : ''
 
     " Identify the lines to be operated on...
-    exec 'silent lvimgrep /' . sensitive . @/ . '/j %'
-    let matched_line_nums
-    \ = reverse(filter(map(getloclist(0), 'v:val.lnum'), 'start_line <= v:val && v:val <= end_line'))
+    exec 'silent lvimgrep /' . l:sensitive . @/ . '/j %'
+    let l:matched_line_nums
+    \ = reverse(filter(map(getloclist(0), 'v:val.lnum'), 'l:start_line <= v:val && v:val <= l:end_line'))
 
     " Invert the list of lines, if requested...
-    if inverted
-        let inverted_line_nums = range(start_line, end_line)
-        for line_num in matched_line_nums
-            call remove(inverted_line_nums, line_num-start_line)
+    if l:inverted
+        let l:inverted_line_nums = range(l:start_line, l:end_line)
+        for l:line_num in l:matched_line_nums
+            call remove(l:inverted_line_nums, l:line_num-l:start_line)
         endfor
-        let matched_line_nums = reverse(inverted_line_nums)
+        let l:matched_line_nums = reverse(l:inverted_line_nums)
     endif
 
     " Filter the original lines...
-    let yanked = ""
-    for line_num in matched_line_nums
+    let l:yanked = ''
+    for l:line_num in l:matched_line_nums
         " Remember yanks or deletions...
-        let yanked = getline(line_num) . "\n" . yanked
+        let l:yanked = getline(l:line_num) . "\n" . l:yanked
 
         " Delete buffer lines if necessary...
-        if deleting
-            exec line_num . 'delete'
+        if l:deleting
+            exec l:line_num . 'delete'
         endif
     endfor
 
@@ -88,20 +88,20 @@ function! ForAllMatches (command, options)
         let l:command = ':let @' . g:YankMatches#ClipboardRegister . ' = yanked'
         execute 'normal! ' . l:command . "\<cr>"
     else
-        let @" = yanked
+        let @" = l:yanked
     endif
 
     " Return to original position...
-    call setpos('.', orig_pos)
+    call setpos('.', l:orig_pos)
 
     " Report results...
     redraw
-    let match_count = len(matched_line_nums)
-    if match_count == 0
+    let l:match_count = len(l:matched_line_nums)
+    if l:match_count == 0
         unsilent echo 'Nothing to ' . a:command . ' (no matches found)'
-    elseif deleting
-        unsilent echo match_count . (match_count > 1 ? ' fewer lines' : ' less line')
+    elseif l:deleting
+        unsilent echo l:match_count . (l:match_count > 1 ? ' fewer lines' : ' less line')
     else
-        unsilent echo match_count . ' line' . (match_count > 1 ? 's' : '') . ' yanked'
+        unsilent echo l:match_count . ' line' . (l:match_count > 1 ? 's' : '') . ' yanked'
     endif
 endfunction


### PR DESCRIPTION
Hey, Not sure if you want these... maybe just a few, but I thought I would add them.

First Commit I did removes the mappings from the actual script. This just makes it a bit easier for a user to map their own stuff, especially if they decide that they don't want to use all of the mappings.

The second commit fixed an array out of bounds error I came across when using the visual selection when I selected lines that were not at the top of the file.

The third commit makes a configuration variable to set the register to save the yanks and deletes into... by default it is the `"` register, but someone may want it elsewhere, and in my case, I set the `set clipboard=unnamedplus` setting, so my default register for paste commands come from the `+` register. I also added some documentation about that in the README.

The last commit just modified the whole script to basically be in accordance with Google's Vimscript Style Guide.